### PR TITLE
Correção da Ordem de Configuração de Autenticação e Identity

### DIFF
--- a/ApiCatalogo/Controllers/AuthController.cs
+++ b/ApiCatalogo/Controllers/AuthController.cs
@@ -30,7 +30,6 @@ namespace ApiCatalogo.Controllers
             _configuration = configuration;
         }
 
-
         [HttpPost]
         [Route("login")]
         public async Task<IActionResult> Login([FromBody] LoginModel model)
@@ -77,13 +76,12 @@ namespace ApiCatalogo.Controllers
             return Unauthorized();
 
         }
-
         [HttpPost]
         [Route("register")]
         public async Task<IActionResult> RegistrarUsuario([FromBody] RegistroModel model)
         {
 
-            var usuarioExiste = await _userManager.FindByEmailAsync(model.NomeUsuario!);
+            var usuarioExiste = await _userManager.FindByNameAsync(model.NomeUsuario!);
 
             if (usuarioExiste is not null)
             {
@@ -107,7 +105,6 @@ namespace ApiCatalogo.Controllers
             return Ok(new Response { Status = "Success", Mensagem = "Usuário criado com sucesso!" });
 
         }
-
         [HttpPost]
         [Route("refresh-token")]
 

--- a/ApiCatalogo/Controllers/CategoriaController.cs
+++ b/ApiCatalogo/Controllers/CategoriaController.cs
@@ -1,24 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading.Tasks;
-using ApiCatalogo.Context;
 using ApiCatalogo.DTOs.Categorias;
 using ApiCatalogo.Models;
 using ApiCatalogo.Pagination;
-using ApiCatalogo.Services;
 using ApiCatalogo.Services.CategoriaService;
 using AutoMapper;
-using Azure.Core;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace ApiCatalogo.Controllers
 {
-    [Route("[controller]")]
+    [Route("api/[controller]")]
     [ApiController]
     public class CategoriaController : ControllerBase
     {
@@ -35,14 +26,14 @@ namespace ApiCatalogo.Controllers
 
 
         [HttpGet]
-        [Authorize]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
         public async Task<ActionResult<CategoriaDTO>> BuscarCategoria()
         {
             var categoria = await _categoriaService.BuscarTodos();
             return Ok(categoria);
         }
 
-
+        [Authorize]
         [HttpGet("CategoriaProduto")]
         public async Task<ActionResult<IEnumerable<CategoriaOutputDTO>>> BuscarCategoriaPorProduto(int id)
         {
@@ -55,6 +46,7 @@ namespace ApiCatalogo.Controllers
             return Ok(categoriaDto);
         }
 
+        [Authorize]
         [HttpGet("paginados")]
         public async Task<ActionResult<PagedModel<CategoriaDTO>>> BuscarCategoriasPaginados(int pagina = 1, int tamanhoPagina = 5)
         {
@@ -72,7 +64,7 @@ namespace ApiCatalogo.Controllers
 
         }
 
-
+        [Authorize]
         [HttpGet("{id:int:min(1)}", Name = "ObterCategoria")]
         public async Task<ActionResult<CategoriaDTO>> BuscarCategoriaPorId(int id)
         {
@@ -89,6 +81,7 @@ namespace ApiCatalogo.Controllers
 
         }
 
+        [Authorize]
         [HttpPost]
         public async Task<ActionResult<CategoriaOutputDTO>> AdicionarCategoria(CategoriaInputDTO categoriaInputDto)
         {
@@ -104,6 +97,7 @@ namespace ApiCatalogo.Controllers
             return new CreatedAtRouteResult("ObterCategoria", new { id = categoriaAdicionar?.CategoriaId }, categoriaAdicionar);
         }
 
+        [Authorize]
         [HttpPut("id")]
         public async Task<ActionResult<CategoriaOutputDTO>> AtualizarCategoria(int id, CategoriaInputDTO categoriaInput)
         {
@@ -121,7 +115,7 @@ namespace ApiCatalogo.Controllers
 
             return Ok(categoriaOutPut);
         }
-
+        [Authorize]
         [HttpDelete("id")]
 
         public async Task<ActionResult<CategoriaDTO>> DeletarCategoria(int id)

--- a/ApiCatalogo/Controllers/ProdutoController.cs
+++ b/ApiCatalogo/Controllers/ProdutoController.cs
@@ -9,6 +9,7 @@ using ApiCatalogo.Models;
 using ApiCatalogo.Pagination;
 using ApiCatalogo.Services.ProdutoService;
 using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -17,7 +18,7 @@ using Microsoft.Extensions.Logging;
 namespace ApiCatalogo.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("api/[controller]")]
     public class ProdutoController : ControllerBase
     {
 
@@ -34,7 +35,7 @@ namespace ApiCatalogo.Controllers
 
         }
 
-
+        [Authorize]
         [HttpGet]
         public async Task<ActionResult<IEnumerable<ProdutoDTO>>> BuscarProduto()
         {
@@ -50,6 +51,7 @@ namespace ApiCatalogo.Controllers
 
         }
 
+        [Authorize]
         [HttpGet("paginados")]
         public async Task<ActionResult<PagedModel<ProdutoDTO>>> BuscarProdutosPaginados(int pagina = 1, int tamanhoPagina = 5)
         {
@@ -67,7 +69,7 @@ namespace ApiCatalogo.Controllers
         }
 
 
-
+        [Authorize]
         [HttpGet("{id}", Name = "ObterProduto")]
 
         public async Task<ActionResult<ProdutoDTO>> BuscarProdutoId(int id)
@@ -84,7 +86,7 @@ namespace ApiCatalogo.Controllers
 
         }
 
-
+        [Authorize]
         [HttpPost]
 
         public async Task<ActionResult<ProdutoOutputDTO>> AdicionarProduto(ProdutoInputDTO produtoDto)
@@ -98,8 +100,8 @@ namespace ApiCatalogo.Controllers
 
         }
 
+        [Authorize]
         [HttpPut]
-
         public async Task<ActionResult<ProdutoOutputDTO>> AtualizarProduto(ProdutoInputDTO produtoDto)
         {
             var produtoMapeado = _mapper.Map<Produto>(produtoDto);
@@ -112,6 +114,7 @@ namespace ApiCatalogo.Controllers
 
         }
 
+        [Authorize]
         [HttpDelete("{id}")]
 
         public async Task<ActionResult<ProdutoDTO>> ExcluirProduto(int id)


### PR DESCRIPTION
Eu identifiquei um comportamento inesperado nas rotas autenticadas da API, onde endpoints protegidos pelo atributo [Authorize] retornavam erro 404 mesmo com um token JWT válido. Isso ocorria porque a ordem de configuração dos serviços AddIdentity e AddAuthentication no Program.cs estava definindo implicitamente um esquema de autenticação conflitante (Cookies), sobrescrevendo a configuração JWT.

### Problema:
A chamada AddIdentity antes de AddAuthentication definia o esquema padrão de autenticação como Cookies (mesmo sem uso explícito), invalidando o JWT.

Isso exigia a declaração explícita do esquema JWT em cada [Authorize] (ex: [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]).

Rotas autenticadas retornavam 404 devido à falha silenciosa na autenticação.